### PR TITLE
bump zlib to 1.3.2, fetch source from GitHub

### DIFF
--- a/Abstract/rv-ruby-32.rb
+++ b/Abstract/rv-ruby-32.rb
@@ -35,7 +35,7 @@ class RvRuby32 < Formula
         depends_on "portable-libedit" => :build
         depends_on "portable-libffi@3.5.1" => :build
         depends_on "portable-libxcrypt@4.4.38" => :build
-        depends_on "portable-zlib@1.3.1" => :build
+        depends_on "portable-zlib@1.3.2" => :build
 
         if build.without? "yjit"
           on_intel do

--- a/Abstract/rv-ruby-33.rb
+++ b/Abstract/rv-ruby-33.rb
@@ -34,7 +34,7 @@ class RvRuby33 < Formula
       on_linux do
         depends_on "portable-libffi@3.5.1" => :build
         depends_on "portable-libxcrypt@4.4.38" => :build
-        depends_on "portable-zlib@1.3.1" => :build
+        depends_on "portable-zlib@1.3.2" => :build
 
         if build.without? "yjit"
           on_intel do

--- a/Abstract/rv-ruby-34.rb
+++ b/Abstract/rv-ruby-34.rb
@@ -34,7 +34,7 @@ class RvRuby34 < Formula
       on_linux do
         depends_on "portable-libffi@3.5.1" => :build
         depends_on "portable-libxcrypt@4.4.38" => :build
-        depends_on "portable-zlib@1.3.1" => :build
+        depends_on "portable-zlib@1.3.2" => :build
 
         if build.without? "yjit"
           on_intel do

--- a/Abstract/rv-ruby.rb
+++ b/Abstract/rv-ruby.rb
@@ -35,7 +35,7 @@ class RvRuby < Formula
       on_linux do
         depends_on "portable-libffi@3.5.1" => :build
         depends_on "portable-libxcrypt@4.4.38" => :build
-        depends_on "portable-zlib@1.3.1" => :build
+        depends_on "portable-zlib@1.3.2" => :build
 
         if build.without?("yjit") && build.without?("zjit")
           on_intel do

--- a/Formula/portable-zlib@1.3.2.rb
+++ b/Formula/portable-zlib@1.3.2.rb
@@ -1,13 +1,10 @@
 require File.expand_path("../Abstract/portable-formula", __dir__)
 
-class PortableZlibAT131 < PortableFormula
+class PortableZlibAT132 < PortableFormula
   desc "General-purpose lossless data-compression library"
   homepage "https://zlib.net/"
-  url "https://zlib.net/zlib-1.3.1.tar.gz"
-  mirror "https://downloads.sourceforge.net/project/libpng/zlib/1.3.1/zlib-1.3.1.tar.gz"
-  mirror "http://fresh-center.net/linux/misc/zlib-1.3.1.tar.gz"
-  mirror "http://fresh-center.net/linux/misc/legacy/zlib-1.3.1.tar.gz"
-  sha256 "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
+  url "https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz"
+  sha256 "bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16"
   license "Zlib"
 
   livecheck do


### PR DESCRIPTION
this was instigated by the previous zlib source URL no longer being accessible